### PR TITLE
fix: force update to push image on PR merge

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -22,4 +22,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push image
-        run: ./check-updates.sh --push
+        run: ./check-updates.sh --force --push


### PR DESCRIPTION
At the time on merge, the version file is already updated.

So we need to force the update to push the built image.