### PR TITLE
fix: issue #51 Create provenance attestations

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -152,6 +152,8 @@ echo "$@" | grep 'buildx' >/dev/null && {
   docker buildx build \
     $doPush \
     --sbom=true \
+    --provenance=true \
+    --provenance=mode=max \
     --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
     --tag "$NAME_IMAGE_LATEST" .
 
@@ -159,9 +161,12 @@ echo "$@" | grep 'buildx' >/dev/null && {
   docker buildx build \
     $doPush \
     --sbom=true \
+    --provenance=true \
+    --provenance=mode=max \
     --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
     --tag "$NAME_IMAGE_VERSIONED" .
 
+  # Shutdown the builder
   docker buildx stop "$NAME_MULTIARCH_BUILDER"
 }
 


### PR DESCRIPTION
- fix to avoid supply chain attestations warning. - Images should have both a SBOM (software bill of materials) and a provenance attached. SBOM is already done but provenance attachment.