### PR TITLE
fix: attestation of provenance with mode max

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
 # -----------------------------------------------------------------------------
 FROM alpine:latest AS build
 
-ARG BUILDKIT_SBOM_SCAN_STAGE=true
-
 # Install dependencies
 RUN \
   apk update && \
@@ -48,6 +46,8 @@ RUN /run-test.sh
 #  Main Stage
 # -----------------------------------------------------------------------------
 FROM alpine:latest
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 COPY --from=build /usr/bin/sqlite3 /usr/bin/sqlite3
 COPY run-test.sh /run-test.sh

--- a/build-images.sh
+++ b/build-images.sh
@@ -152,7 +152,7 @@ echo "$@" | grep 'buildx' >/dev/null && {
   docker buildx build \
     $doPush \
     --sbom=true \
-    --provenance=true \
+    --attest type=provenance,mode=max \
     --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
     --tag "$NAME_IMAGE_LATEST" .
 
@@ -160,7 +160,7 @@ echo "$@" | grep 'buildx' >/dev/null && {
   docker buildx build \
     $doPush \
     --sbom=true \
-    --provenance=true \
+    --attest type=provenance,mode=max \
     --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
     --tag "$NAME_IMAGE_VERSIONED" .
 


### PR DESCRIPTION
- set `BUILDKIT_SBOM_SCAN_STAGE=true` argument in the final stage of docker build as well