### PR TITLE
doc: use single quotes in sample SQL otherwise sqlite complains

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Connected to a transient in-memory database.
 Use ".open FILENAME" to reopen on a persistent database.
 sqlite> .open ./sample.db
 sqlite> CREATE TABLE table_sample(timestamp TEXT, description TEXT);
-sqlite> INSERT INTO table_sample VALUES(datetime("now"),"First sample data. Foo");
-sqlite> INSERT INTO table_sample VALUES(datetime("now"),"Second sample data. Bar");
+sqlite> INSERT INTO table_sample VALUES(datetime('now'),'First sample data. Foo');
+sqlite> INSERT INTO table_sample VALUES(datetime('now'),'Second sample data. Bar');
 sqlite> .quit
 $ ls
 sample.db


### PR DESCRIPTION
with the double quotes, sqlite errors with:
```
Parse error: no such column: "now" - should this be a string literal in single-quotes?
```